### PR TITLE
Bump dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,15 +46,13 @@
         <isRelease>false</isRelease>
         <sonar.dynamicAnalysis>true</sonar.dynamicAnalysis>
         <sonar.host.url>http://sonarqube.com</sonar.host.url>
-
-        <!-- Make sure to update below dependencies as these are not updated from Spring Boot BOM-->
     </properties>
 
     <build>
         <plugins>
             <plugin>
                 <artifactId>maven-scm-plugin</artifactId>
-                <version>1.4</version>
+                <version>1.11.2</version>
                 <configuration>
                     <tag>${project.artifactId}-0.0.11-SNAPSHOT</tag>
                 </configuration>
@@ -91,7 +89,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>3.7.1</version>
+                    <version>3.8.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -386,12 +384,12 @@
             <dependency>
                 <groupId>org.javassist</groupId>
                 <artifactId>javassist</artifactId>
-                <version>3.25.0-GA</version>
+                <version>3.26.0-GA</version>
             </dependency>
             <dependency>
                 <groupId>net.bytebuddy</groupId>
                 <artifactId>byte-buddy</artifactId>
-                <version>1.10.2</version>
+                <version>1.10.7</version>
             </dependency>
             <dependency>
                 <groupId>commons-beanutils</groupId>


### PR DESCRIPTION
Bump javassist from 3.25.0-GA to 3.26.0-GA
Bump hibernate-search-orm from 5.11.1.Final to 5.11.4.Final
Bump byte-buddy from 1.10.2 to 1.10.7
Bump maven-scm-plugin from 1.4 to 1.11.2